### PR TITLE
Added live controller with url auto refreshed

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,15 +1,7 @@
-import { registerReactControllerComponents } from '@symfony/ux-react';
+import { Application } from '@hotwired/stimulus';
 import './bootstrap.js';
-/*
- * Welcome to your app's main JavaScript file!
- *
- * This file will be included onto the page via the importmap() Twig function,
- * which should already be in your base.html.twig.
- */
 import './styles/app.css';
 
 console.log('This log comes from assets/app.js - welcome to AssetMapper! 🎉');
 
-
-registerReactControllerComponents(require.context('./react/controllers', true, /\.(j|t)sx?$/));
-registerReactControllerComponents();
+const app = Application.start();

--- a/assets/controllers/url_controller.js
+++ b/assets/controllers/url_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus";
+import { getComponent } from '@symfony/ux-live-component';
+
+export default class extends Controller {
+    async initialize() {
+        const liveComponents = document.querySelectorAll("[data-controller='live']");
+
+        liveComponents.forEach(async (element) => {
+            const component = await getComponent(element);
+
+            component.on("render:finished", this.replacePathname.bind(this, element));
+        });
+    }
+
+    replacePathname(element) {
+        if (element.dataset.url) {
+            const currentUrl = new URL(window.location.href);
+            const newUrl = new URL(element.dataset.url, currentUrl.origin);
+
+            currentUrl.pathname = newUrl.pathname;
+
+            history.replaceState({}, "", currentUrl.toString());
+            console.log("Pathname replaced to:", currentUrl.pathname);
+        }
+    }
+
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,5 +1,9 @@
 body {
-    /*background-color: skyblue;*/
+    background: linear-gradient(to right, #2c3e50, #4ca1af);
+    color: #f8f9fa;
+    font-family: 'Roboto', sans-serif;
+    margin: 0;
+    padding: 0;
 }
 
 .clipboard-button {
@@ -8,4 +12,141 @@ body {
 
 .clipboard--supported .clipboard-button {
     display: initial;
+}
+
+.container {
+    max-width: 100%;
+    background: rgba(255, 255, 255, 0.1);
+    padding: 20px;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    margin-top: 50px;
+}
+
+h1 {
+    text-align: center;
+    font-size: 2rem;
+    text-transform: uppercase;
+    color: #f8f9fa;
+    margin-bottom: 20px;
+}
+
+h2 {
+    color: #f1c40f;
+}
+
+label {
+    font-weight: bold;
+}
+
+select {
+    background: #2c3e50;
+    color: #f8f9fa;
+    padding: 5px;
+    border: none;
+    border-radius: 5px;
+}
+
+ul {
+    list-style: none;
+    padding: 0;
+}
+
+ul li {
+    background: rgba(255, 255, 255, 0.2);
+    padding: 10px;
+    margin: 5px 0;
+    border-radius: 5px;
+    transition: background 0.3s ease-in-out;
+}
+
+ul li:hover {
+    background: rgba(255, 255, 255, 0.4);
+}
+
+select, button {
+    cursor: pointer;
+    transition: 0.3s;
+}
+
+select:hover, button:hover {
+    transform: scale(1.05);
+}
+
+button {
+    background: linear-gradient(45deg, #f39c12, #e74c3c);
+    color: #ffffff;
+    font-size: 1rem;
+    font-weight: bold;
+    padding: 10px 15px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: all 0.3s ease-in-out;
+    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+button:hover {
+    background: linear-gradient(45deg, #e67e22, #c0392b);
+    transform: scale(1.05);
+    box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.3);
+}
+
+button:active {
+    transform: scale(0.95);
+    box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+button:disabled {
+    background: #95a5a6;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.btn-secondary {
+    background: linear-gradient(45deg, #3498db, #2980b9);
+}
+
+.btn-secondary:hover {
+    background: linear-gradient(45deg, #2980b9, #1c6ea4);
+}
+
+.btn-rounded {
+    border-radius: 30px;
+}
+
+.btn-large {
+    padding: 15px 20px;
+    font-size: 1.2rem;
+}
+
+.btn-small {
+    padding: 5px 10px;
+    font-size: 0.8rem;
+}
+
+.block-components {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 20px;
+    padding: 10px;
+}
+
+.block-components > * {
+    background: rgba(255, 255, 255, 0.15);
+    padding: 15px;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    flex: 1;
+    min-width: 180px;
+    text-align: center;
+}
+
+@media (max-width: 768px) {
+    .block-components {
+        flex-direction: column;
+        align-items: stretch;
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/string": "7.1.*",
         "symfony/translation": "7.1.*",
         "symfony/twig-bundle": "7.1.*",
-        "symfony/ux-live-component": "^2.17",
+        "symfony/ux-live-component": "^2.22",
         "symfony/ux-react": "^2.17",
         "symfony/ux-turbo": "^2.17",
         "symfony/validator": "7.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4803616836f91f0dcb83adfdc7bf8e76",
+    "content-hash": "d74bd58c6ba666f351a17b4e51cdea39",
     "packages": [
         {
             "name": "amphp/amp",
@@ -8386,20 +8386,21 @@
         },
         {
             "name": "symfony/ux-live-component",
-            "version": "v2.20.0",
+            "version": "v2.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-live-component.git",
-                "reference": "c05ac6bfa7368415676d74183eded05be2635a1d"
+                "reference": "060e0c64e64125a4dfbf37dec281157faade1feb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-live-component/zipball/c05ac6bfa7368415676d74183eded05be2635a1d",
-                "reference": "c05ac6bfa7368415676d74183eded05be2635a1d",
+                "url": "https://api.github.com/repos/symfony/ux-live-component/zipball/060e0c64e64125a4dfbf37dec281157faade1feb",
+                "reference": "060e0c64e64125a4dfbf37dec281157faade1feb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
                 "symfony/property-access": "^5.4.5|^6.0|^7.0",
                 "symfony/stimulus-bundle": "^2.9",
                 "symfony/ux-twig-component": "^2.8",
@@ -8432,8 +8433,8 @@
             "type": "symfony-bundle",
             "extra": {
                 "thanks": {
-                    "name": "symfony/ux",
-                    "url": "https://github.com/symfony/ux"
+                    "url": "https://github.com/symfony/ux",
+                    "name": "symfony/ux"
                 }
             },
             "autoload": {
@@ -8459,7 +8460,7 @@
                 "twig"
             ],
             "support": {
-                "source": "https://github.com/symfony/ux-live-component/tree/v2.20.0"
+                "source": "https://github.com/symfony/ux-live-component/tree/v2.22.1"
             },
             "funding": [
                 {
@@ -8475,7 +8476,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-24T09:27:42+00:00"
+            "time": "2024-12-07T10:13:15+00:00"
         },
         {
             "name": "symfony/ux-react",
@@ -12208,7 +12209,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -12216,6 +12217,6 @@
         "ext-ctype": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/src/Controller/LiveController.php
+++ b/src/Controller/LiveController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class LiveController extends AbstractController
+{
+    #[Route('/live/{chapter}/{letter}', name: 'app_live')]
+    public function index(string $chapter, string $letter): Response
+    {
+        return $this->render('live/index.html.twig', [
+            'letter' => $letter,
+            'chapter' => $chapter,
+        ]);
+    }
+}

--- a/src/Name/Store.php
+++ b/src/Name/Store.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Name;
+
+final class Store
+{
+    public function all(): array
+    {
+        return [
+            'A' => ['Alice', 'Andrew', 'Amanda', 'Albert', 'Anna', 'Aaron', 'Ashley', 'Amber', 'Austin', 'Abigail'],
+            'B' => ['Brian', 'Barbara', 'Benjamin', 'Brittany', 'Brad', 'Brenda', 'Blake', 'Becky', 'Barry', 'Bella'],
+            'C' => ['Charles', 'Catherine', 'Chris', 'Cynthia', 'Connor', 'Chloe', 'Caleb', 'Clara', 'Carl', 'Carol'],
+        ];
+    }
+
+    public function getByLetter(string $letter, int $limit = 10): array
+    {
+        $letter = strtoupper($letter);
+        $namesByLetter = $this->all();
+
+        if (!isset($namesByLetter[$letter])) {
+            return [];
+        }
+
+        return array_slice($namesByLetter[$letter], 0, $limit);
+    }
+
+    public function getLetters(): array
+    {
+        return ['a', 'b', 'c'];
+    }
+}

--- a/src/Twig/Components/Chapter.php
+++ b/src/Twig/Components/Chapter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Twig\Components;
+
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent]
+final class Chapter
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true)]
+    public string $chapter;
+
+    public function getUrlProps(): array
+    {
+        return ['chapter' => $this->chapter];
+    }
+
+    #[LiveAction]
+    public function changeChapter(#[LiveArg] string $chapter): void
+    {
+        $this->chapter = $chapter;
+    }
+}

--- a/src/Twig/Components/Names.php
+++ b/src/Twig/Components/Names.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Twig\Components;
+
+use App\Name\Store;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent]
+final class Names
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true)]
+    public string $letter;
+
+
+    #[LiveProp(writable: true, url: true)]
+    public int $limit = 5;
+
+    public function __construct(private readonly Store $nameStore)
+    {
+
+    }
+
+    public function getUrlProps(): array
+    {
+        return ['letter' => $this->letter];
+    }
+
+    #[LiveAction]
+    public function changeLetter(#[LiveArg] string $letter): void
+    {
+        $this->letter = $letter;
+    }
+
+    #[LiveAction]
+    public function changeLetterAndLimit(#[LiveArg] string $letter, #[LiveArg] string $limit): void
+    {
+        $this->letter = $letter;
+        $this->limit = $limit;
+    }
+
+    #[LiveAction]
+    public function changeLimit(#[LiveArg] string $limit): void
+    {
+        $this->limit = $limit;
+    }
+
+    public function getNames(): array
+    {
+        return $this->nameStore->getByLetter($this->letter, $this->limit);
+    }
+
+    public function getLetters(): array
+    {
+        return $this->nameStore->getLetters();
+    }
+}

--- a/src/Twig/Components/Number.php
+++ b/src/Twig/Components/Number.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Twig\Components;
+
+use App\Name\Store;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+#[AsLiveComponent]
+final class Number
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: true, url: true)]
+    public int $number;
+
+    public function __construct()
+    {
+
+    }
+
+    #[LiveAction]
+    public function changeNumber(#[LiveArg] int $number): void
+    {
+        $this->number = $number;
+    }
+
+    public function getResult(): int
+    {
+        return $this->number * 1000;
+    }
+}

--- a/src/Twig/Extension/UrlBuilderExtension.php
+++ b/src/Twig/Extension/UrlBuilderExtension.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Twig\Extension;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RouterInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class UrlBuilderExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly RouterInterface $router
+    ) {}
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('build_url', [$this, 'buildUrl']),
+        ];
+    }
+
+    // Too many route manipulations
+    public function buildUrl(array $props = []): string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request) {
+            throw new \LogicException("No current request available. Make sure this function is called within a request context.");
+        }
+
+        $currentRoute = $request->attributes->get('_route');
+
+        if (!$currentRoute) {
+            throw new \LogicException("Unable to determine the current route.");
+        }
+
+        $params = $request->attributes->get('_route_params');
+        if (str_contains($currentRoute, 'ux_live_component')) {
+            $url = $request->headers->get('referer'); // Not sure if it works everytime
+            $parsedUrl = parse_url($url);
+            $route = $this->router->match($parsedUrl['path']);
+            $currentRoute = $route['_route'];
+
+            foreach ($props as $index => $prop) {
+                $route[$index] = $prop;
+            }
+
+            unset($route['_route']);
+            unset($route['_controller']);
+
+            $params = $route;
+        }
+
+        return $this->router->generate($currentRoute, $params);
+    }
+}

--- a/templates/components/Chapter.html.twig
+++ b/templates/components/Chapter.html.twig
@@ -1,0 +1,13 @@
+<div
+        {{ attributes }}
+        data-url="{{ build_url(this.urlProps) }}" {# To be guessed automatically and set by PHP Component code as attributes values for props #}
+>
+    <h2>Chapter : {{ this.chapter }}</h2>
+    <div>
+        <button class="btn-small" {{ live_action('changeChapter', {'chapter': 'chapter-1'}) }}>Chapter 1</button>
+        <button class="btn-small" {{ live_action('changeChapter', {'chapter': 'chapter-2'}) }}>Chapter 2</button>
+        <button class="btn-small" {{ live_action('changeChapter', {'chapter': 'chapter-3'}) }}>Chapter 3</button>
+        <button class="btn-small" {{ live_action('changeChapter', {'chapter': 'chapter-4'}) }}>Chapter 4</button>
+        <button class="btn-small" {{ live_action('changeChapter', {'chapter': 'chapter-5'}) }}>Chapter 5</button>
+    </div>
+</div>

--- a/templates/components/Names.html.twig
+++ b/templates/components/Names.html.twig
@@ -1,0 +1,34 @@
+<div
+        {{ attributes }}
+        data-url="{{ build_url(this.urlProps) }}" {# To be guessed automatically and set by PHP Component code as attributes values for props #}
+>
+    <h2>Limit : {{ this.limit }}</h2>
+    <label>
+        Choose a limit :
+
+        <button class="btn-small" {{ live_action('changeLimit', {'limit': 1}) }}>1</button>
+        <button class="btn-small" {{ live_action('changeLimit', {'limit': 5}) }}>5</button>
+        <button class="btn-small" {{ live_action('changeLimit', {'limit': 10}) }}>10</button>
+    </label>
+    <h2>Letter : {{ this.letter|upper }}</h2>
+    <label>
+        Choose a letter :
+
+        <button class="btn-small" {{ live_action('changeLetter', {'letter': 'a'}) }}>Letter A</button>
+        <button class="btn-small" {{ live_action('changeLetter', {'letter': 'b'}) }}>Letter B</button>
+        <button class="btn-small" {{ live_action('changeLetter', {'letter': 'c'}) }}>Letter C</button>
+    </label>
+    <h2>Change letter & limit :</h2>
+    <label>
+        Choose a letter & limit combo :
+
+        <button class="btn-small" {{ live_action('changeLetterAndLimit', {'letter': 'a', 'limit': 8}) }}>A & 8</button>
+        <button class="btn-small" {{ live_action('changeLetterAndLimit', {'letter': 'b', 'limit': 3}) }}>B & 3</button>
+        <button class="btn-small" {{ live_action('changeLetterAndLimit', {'letter': 'c', 'limit': 6}) }}>C & 6</button>
+    </label>
+    <ul>
+        {% for name in this.names %}
+            <li>{{ name }}</li>
+        {% endfor %}
+    </ul>
+</div>

--- a/templates/components/Number.html.twig
+++ b/templates/components/Number.html.twig
@@ -1,0 +1,11 @@
+<div {{ attributes }}>
+    <h2>Number : {{ this.number }}</h2>
+    <div>
+        <button class="btn-small" {{ live_action('changeNumber', {'number': 1}) }}>Number 1</button>
+        <button class="btn-small" {{ live_action('changeNumber', {'number': 2}) }}>Number 2</button>
+        <button class="btn-small" {{ live_action('changeNumber', {'number': 3}) }}>Number 3</button>
+        <button class="btn-small" {{ live_action('changeNumber', {'number': 4}) }}>Number 4</button>
+        <button class="btn-small" {{ live_action('changeNumber', {'number': 5}) }}>Number 5</button>
+    </div>
+    <h3>Result : {{ this.result }}</h3>
+</div>

--- a/templates/live/index.html.twig
+++ b/templates/live/index.html.twig
@@ -1,0 +1,17 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Hello LiveController!{% endblock %}
+
+{% block body %}
+    <div class="example-wrapper">
+        {# To be injected seemlessly #}
+        <div data-controller="url"></div>
+        <h1>Hello live</h1>
+
+        <div class="block-components">
+            <twig:Chapter chapter="{{ chapter }}"/>
+            <twig:Names letter="{{ letter }}"/>
+            <twig:Number number="1"/>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
# How to Test :

- Go to the page http://blog.taymik.com/live/chapter-3/b?number=3
- This page has 3 live components, one is using a prop set in the queryString and the two others avec props set in the pathname
- Change the letter (or chapter) and notice that the URL is updated with the correct format while keeping the props of the Number live component in the Query String


# Explanations :

- The Stimulus controller letters is updated to listen for the render:finished event emitted by the Live Component.
- The replacePathname() method is called to update the URL after each re-render of the component.

## Some notes :
- Coexistence works with three Live Components:

1.  One that has a prop only in the pathname.
2.  A second one that has a prop in the pathname and another in the query string.
3.  A third one that has a prop only in the query string.

- A method needs to be defined in Live Components that want to modify the pathname, which returns the list of props to inject. I would have preferred this to be automatic in the LiveProp attribute.

- A data-url attribute must be added to Live Components that want to modify the pathname.

- I created a Twig extension that manipulates routes and reconstructs URLs manually with the correct parameters.

- An independent Stimulus controller is required to perform history.replaceState on the render:finished event of Live Components.
- Problem: If you have two Live Components that use the same prop name, you can only set aliases in the query string. It's not possible to have these aliases in the pathname with the Symfony route.
- I use the referer in the request when I need to retrieve the base URL during the Live Component refresh, not sure if it is recommanded